### PR TITLE
Fix hardcoding of North and East on GPS position and added custom comment

### DIFF
--- a/SVTrackR.ino
+++ b/SVTrackR.ino
@@ -94,6 +94,10 @@
  24 Dec 2014 ( v1.1 )
  - Added comment parsing codes from latest MicroAPRS libs
  - Added status ">" type parsing
+
+ 15 Mar 2015 ( v1.2 )
+ - Fixed the hardcoding of the North and East on the GPS position
+ - Added custom comment on APRS packet
   
 */
 
@@ -805,15 +809,23 @@ void TxtoRadio() {
        latDegMin = convertDegMin(lastTxLat);
        lngDegMin = convertDegMin(lastTxLng);
 
-       dtostrf(latDegMin, 2, 2, tmp );
-       latOut.concat("lla0");      // set latitute command with the 0
+       dtostrf(fabs(latDegMin), 2, 2, tmp );
+       latOut.concat("lla");      // set latitute command with the 0
        latOut.concat(tmp);
-       latOut.concat("N");
+       if (latDegMin >= 0) {
+           latOut.concat("N");
+       } else if (latDegMin < 0) {
+           latOut.concat("S");
+       }
      
-       dtostrf(lngDegMin, 2, 2, tmp );
-       lngOut.concat("llo");       // set longtitute command
+       dtostrf(fabs(lngDegMin), 2, 2, tmp );
+       lngOut.concat("llo0");       // set longtitute command
        lngOut.concat(tmp);
-       lngOut.concat("E");
+       if (lngDegMin >= 0) {
+           lngOut.concat("E");
+       } else if (latDegMin < 0) {
+           lngOut.concat("W");
+       }
      
        cmtOut.concat("@");
        cmtOut.concat(padding((int) gps.course.deg(),3));
@@ -822,7 +834,9 @@ void TxtoRadio() {
        cmtOut.concat("/A=");
        cmtOut.concat(padding((int)gps.altitude.feet(),6));
        cmtOut.concat(" Seq:");
-       cmtOut.concat(txCounter);       
+       cmtOut.concat(txCounter);
+       cmtOut.concat(" ");       
+       cmtOut.concat(COMMENT);
 
 #ifdef DEBUG          
        debug.print("STR: ");

--- a/config.h
+++ b/config.h
@@ -4,13 +4,14 @@
 // Refer to http://wa8lmf.net/aprs/APRS_symbols.htm
 #define SYMBOL_CHAR '('         // Red Car
 #define SYMBOL_TABLE 's'        // Primary Table (s) or Alternate Table (a)
+// Define custom comment for APRS packets
+#define COMMENT "Custom comment"
 // Define your home lat & lon below
 // http://andrew.hedges.name/experiments/convert_lat_long/
 // Goto aprs.fi and find your deg mm.mm ( leave the secs blank )
 // home
 const float HOME_LAT = 3.159777;
 const float HOME_LON = 101.69903;
-
 
 
 


### PR DESCRIPTION
Hi,

I fixed the part where the North and East were hardcoded. Now it concatenates the N or S based on the GPS coordinate signal, and send to the Micromodem the absolute decimal value.

I added too in config.h the option of putting a custom comment on the APRS packet, as can be seen on my station PU2ENG-9.

Hope you merge my changes.

Thank you very much for this great project!
